### PR TITLE
Add portable option (data folder in Hamsket folder)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -15,6 +15,14 @@ const updater = require('./updater');
 const fs = require("fs");
 const path = require('path');
 
+// If 'data' folder exists in Hamsket's folder, set userdata, logs, and usercache path to there
+var basepath = app.getAppPath();
+if (fs.existsSync(path.join(basepath, 'data'))) {
+    app.setPath('userData', path.join(basepath, 'data', 'data'));
+	app.setPath('logs', path.join(basepath, 'data', 'logs'));
+	app.setPath('userCache', path.join(basepath, 'data', 'cache'));
+}
+
 // Initial Config
 const config = new Config({
 	 defaults: {

--- a/electron/main.js
+++ b/electron/main.js
@@ -18,7 +18,7 @@ const path = require('path');
 // If 'data' folder exists in Hamsket's folder, set userdata, logs, and usercache path to there
 var basepath = app.getAppPath();
 if (fs.existsSync(path.join(basepath, 'data'))) {
-    app.setPath('userData', path.join(basepath, 'data', 'data'));
+	app.setPath('userData', path.join(basepath, 'data', 'data'));
 	app.setPath('logs', path.join(basepath, 'data', 'logs'));
 	app.setPath('userCache', path.join(basepath, 'data', 'cache'));
 }


### PR DESCRIPTION
For #44 
I use this in my own environment for months, but it had a small issue under Window where Electron itself keep creating an empty 'logs' folder (refer to https://github.com/electron/electron/issues/14276)
It has been resolved, so I decided to share this.

To enable portable mode, create 'data' folder within Hamsket's folder.
This is inspired by how VS Code enable portable mode:
https://code.visualstudio.com/docs/editor/portable

Thanks!