### PR TITLE
Replaced deprecated functions

### DIFF
--- a/app/ux/WebView.js
+++ b/app/ux/WebView.js
@@ -775,7 +775,7 @@ Ext.define('Hamsket.ux.WebView',{
 	}
 	,setZoomLevel(level)
 	{
-		this.getWebContents().setZoomLevel(level);
+		this.getWebContents().zoomLevel = level;
 	}
 
 	,zoomIn() {

--- a/electron/main.js
+++ b/electron/main.js
@@ -249,7 +249,7 @@ function updateBadge(title) {
 
 		mainWindow.webContents.send('setBadge', messageCount);
 	} else { // macOS & Linux
-		app.setBadgeCount(messageCount);
+		app.badgeCount = messageCount;
 	}
 
 	if ( messageCount > 0 && !mainWindow.isFocused() && !config.get('dont_disturb') && config.get('flash_frame') ) mainWindow.flashFrame(true);

--- a/electron/menu.js
+++ b/electron/menu.js
@@ -2,7 +2,7 @@
 const os = require('os');
 const {app, BrowserWindow, Menu, shell}  = require('electron');
 const path = require('path');
-const appName = app.getName();
+const appName = app.name;
 
 function sendAction(action, ...args) {
 	const win = BrowserWindow.getAllWindows()[0];
@@ -49,7 +49,7 @@ module.exports = function(config) {
 
 	<!-- DON'T REMOVE THE FOLLOWING LINES -->
 	-
-	> ${app.getName()} ${app.getVersion()}
+	> ${app.name} ${app.getVersion()}
 	> Electron ${process.versions.electron}
 	> ${process.platform} ${process.arch} ${os.release()}
 	> ${buildversion}`;


### PR DESCRIPTION
`app.getName()`, `app.setBadgeCount(count)` and `contents.setZoomLevel(level)` have been deprecated in 7.0.0 and were replaced with `app.name`, `app.badgeCount` and `contents.zoomLevel` respectively. This PR replaces all instances of those functions with the new properties, causing Electron to no longer output deprecation warnings.