### PR TITLE
Fix the unread counter for muted conversations

### DIFF
--- a/app/store/ServicesList.js
+++ b/app/store/ServicesList.js
@@ -883,7 +883,7 @@ Ext.define('Hamsket.store.ServicesList', {
 			,description: 'Text on your computer with Messages for web.'
 			,url: 'https://messages.google.com/web'
 			,type: 'messaging'
-			,js_unread: `let checkUnread=()=>{hamsket.updateBadge(Array.prototype.slice.apply(document.querySelectorAll(".text-content.unread")).reduce((c,b) => b.querySelector(".notifications-off")||1,0))};setInterval(checkUnread,3e3);`
+			,js_unread: `let checkUnread=()=>{hamsket.updateBadge(Array.prototype.slice.apply(document.querySelectorAll(".text-content.unread")).reduce((c,b) => !b.querySelector(".notifications-off")+c,0))};setInterval(checkUnread,3e3);`
 		}
 	]
 });


### PR DESCRIPTION
Apologies @TheGoddessInari , in the #163 the unread counter was actually defunct since it only showed if there's an unread message or not (if was either true or false). This change allows to display the count properly, even for muted conversations.

I hope it's done properly now...