### PR TITLE
Fix Slack Icon after Redesign

### DIFF
--- a/app/util/IconLoader.js
+++ b/app/util/IconLoader.js
@@ -23,7 +23,7 @@ Ext.define('Hamsket.util.IconLoader', {
 						`(() => {
 							let icon = document.querySelector('.c-team_icon');
 							if (!icon) {
-								const doc = document.querySelector('#team-menu-trigger');
+								const doc = document.querySelector('#team-menu-trigger') || document.querySelector('.p-ia__sidebar_header__button');
 								if (doc) {
 									doc.click();
 									icon = document.querySelector('.c-team_icon');


### PR DESCRIPTION
Check for both (old and new) menu icons now, then click it. 

Slack got a new design, the MenuClass changed, so we need to click on another item, to open up the menu, and then fetch the icon.